### PR TITLE
Stop tracking Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh pr merge:*)",
-      "PowerShell(gh pr merge:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config*.json.*.bak
 /nbproject/
 *.trace.db
 /jdbgen-*/
+.claude


### PR DESCRIPTION
`.claude/settings.json` is local tooling configuration rather than part of the project, so it is removed from the repository and `.claude` is added to `.gitignore`.