### PR TITLE
Fix the about dialog icon and desktop handler registration

### DIFF
--- a/src/main/java/comart/tools/jdbgen/ui/JDBAbout.java
+++ b/src/main/java/comart/tools/jdbgen/ui/JDBAbout.java
@@ -23,6 +23,7 @@
  */
 package comart.tools.jdbgen.ui;
 
+import comart.utils.AppDirs;
 import comart.utils.I18n;
 import comart.utils.PlatformUtils;
 import comart.utils.UIUtils;
@@ -35,7 +36,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
@@ -125,13 +125,13 @@ public class JDBAbout extends JDialog {
     }
     
     /**
-     * read the bundled application icon and show it in the image label. The
-     * image is scaled smoothly to the size of the label, a resource which
-     * cannot be read is logged and leaves the label empty.
+     * read the application icon shipped with the release and show it in the
+     * image label. The image is scaled smoothly to the size of the label, a
+     * file which cannot be read is logged and leaves the label empty.
      */
     private void loadAppIcon() {
-        try (InputStream is = getClass().getResourceAsStream("/icons/generic.png") ){
-            BufferedImage img = ImageIO.read(is);
+        try {
+            BufferedImage img = ImageIO.read(AppDirs.installResourceFile("resource/icon.png"));
             Image dimg = img.getScaledInstance(lblImage.getWidth(), lblImage.getHeight(),
                 Image.SCALE_SMOOTH);
             lblImage.setIcon(new ImageIcon(dimg));

--- a/src/main/java/comart/utils/PlatformUtils.java
+++ b/src/main/java/comart/utils/PlatformUtils.java
@@ -231,19 +231,31 @@ public class PlatformUtils {
             Desktop desk = Desktop.getDesktop();
 
             if (about != null) {
-                desk.setAboutHandler(about);
+                if (desk.isSupported(Desktop.Action.APP_ABOUT))
+                    desk.setAboutHandler(about);
+                else
+                    log.debug("the about handler is not supported on this platform");
             }
 
             if (prefs != null) {
-                desk.setPreferencesHandler(prefs);
+                if (desk.isSupported(Desktop.Action.APP_PREFERENCES))
+                    desk.setPreferencesHandler(prefs);
+                else
+                    log.debug("the preferences handler is not supported on this platform");
             }
 
             if (print != null) {
-                desk.setPrintFileHandler(print);
+                if (desk.isSupported(Desktop.Action.APP_PRINT_FILE))
+                    desk.setPrintFileHandler(print);
+                else
+                    log.debug("the print file handler is not supported on this platform");
             }
 
             if (shut != null) {
-                desk.setQuitHandler(shut);
+                if (desk.isSupported(Desktop.Action.APP_QUIT_HANDLER))
+                    desk.setQuitHandler(shut);
+                else
+                    log.debug("the quit handler is not supported on this platform");
             }
         } catch(Exception e) {
             log.error(e.getLocalizedMessage(), e);


### PR DESCRIPTION
## Summary
- The about dialog showed the bundled generic database icon (`/icons/generic.png`) instead of the application icon. It now loads `resource/icon.png`, the same file the window icon uses via `UIUtils.setApplicationIcon()`.
- `PlatformUtils.registerHandlers()` registered all four desktop handlers inside a single try block, so on Linux the unsupported `APP_ABOUT` action threw, logged an ERROR stack trace, and skipped the remaining registrations (including the supported quit handler). Each handler is now guarded by `Desktop.isSupported()`, and an unsupported action is logged at DEBUG only.

## Testing
- `./gradlew compileJava` passes.
- Verified on Linux: the startup error is gone and the about dialog shows the application icon.