### PR TITLE
Add status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # jdbgen
 
+[![Build](https://github.com/xcomart/jdbgen/actions/workflows/build.yml/badge.svg)](https://github.com/xcomart/jdbgen/actions/workflows/build.yml)
+[![Release](https://img.shields.io/github/v/release/xcomart/jdbgen)](https://github.com/xcomart/jdbgen/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/xcomart/jdbgen/total)](https://github.com/xcomart/jdbgen/releases)
+[![Java](https://img.shields.io/badge/java-11%2B-blue)](https://adoptium.net/)
+[![License](https://img.shields.io/github/license/xcomart/jdbgen)](LICENSE)
+
 jdbgen generates text and source files from database table metadata, using a
 built-in template engine.
 


### PR DESCRIPTION
## Summary
Add five badges at the top of the README:

- **Build** — GitHub Actions `build.yml` workflow status, linked to the Actions page
- **Release** — latest release version via shields.io, updates automatically with each release
- **Downloads** — total release downloads
- **Java** — required Java version (11+, matching the CI build JDK)
- **License** — MIT, detected from the repository LICENSE file

All badge URLs verified to return HTTP 200.